### PR TITLE
hotfix(parse_uri) found buffer overwrite bug

### DIFF
--- a/proxy.c
+++ b/proxy.c
@@ -269,10 +269,13 @@ void parse_uri(const char *uri, char *proto, size_t protolen, char *host,
                size_t hostlen, char *port, size_t portlen, char *path,
                size_t pathlen) {
   char tmpbuf[MAXLINE] = {0}, tmpbuf2[MAXLINE] = {0};
-  splitstr(uri, proto, protolen, tmpbuf, MAXLINE, "://", 3);
-  split(tmpbuf, host, hostlen, tmpbuf2, MAXLINE, ':');
   path[0] = '/';
-  split(tmpbuf2, port, portlen, path + 1, pathlen - 1, '/');
+  // proto & others
+  splitstr(uri, proto, protolen, tmpbuf, MAXLINE, "://", 3);
+  // others & path[option]
+  split(tmpbuf, tmpbuf2, MAXLINE, path + 1, pathlen - 1, '/');
+  // host and port[option]
+  split(tmpbuf2, host, hostlen, port, portlen, ':');
 }
 
 void clienterror(int fd, char *cause, char *errnum, char *shortmsg,

--- a/proxy.c
+++ b/proxy.c
@@ -232,9 +232,9 @@ int split(const char *line, char *left, size_t leftlen, char *right,
 
 int splitstr(const char *line, char *left, size_t leftlen, char *right,
              size_t rightlen, const char *delim, size_t delimlen) {
-  char *pos = strstr(line, delim);
+  const char *pos = strstr(line, delim);
   if (pos == NULL) {
-    return 0;
+    pos = line + strlen(line);
   }
 
   // do copy left

--- a/test.c
+++ b/test.c
@@ -13,12 +13,13 @@ extern void read_requesthdrs(rio_t *rp, char *host, size_t hostlen);
 static void test_read_requesthdrs() {
   TEST_IN
   rio_t rp;
-  char host_result[MAXLINE];
+  char host_result[MAXLINE], firstlne[MAXLINE];
   const char host_answer[MAXLINE] = "www.example.com";
   int stub_hdr_fd;
 
   stub_hdr_fd = open("stub_header.txt", O_RDONLY);
   rio_readinitb(&rp, stub_hdr_fd);
+  Rio_readlineb(&rp, firstlne, MAXLINE);
   read_requesthdrs(&rp, host_result, MAXLINE);
 
   PRINT_S(host_result);


### PR DESCRIPTION
## fix bug

- empty port & empty path in uri (`http://<host>[:port][/path]`)
- `split`, `splitstr` now copy all string to `left` when no delim found